### PR TITLE
Fix an inconsistent behaviour when parsing a TLD with no domain

### DIFF
--- a/DomainParser/DomainParser/BasicRulesParser.swift
+++ b/DomainParser/DomainParser/BasicRulesParser.swift
@@ -19,9 +19,6 @@ public struct BasicRulesParser {
         let hostComponents = lowercasedHost.split(separator: ".")
         var hostSlices = ArraySlice(hostComponents)
         
-        /// A host must have at least two parts else it's a TLD
-        guard hostSlices.count > 1 else { return nil }
-        
         var candidateSuffix = ""
         
         /// Check if the host ends with a suffix in the set

--- a/DomainParser/DomainParser/ParsedHost.swift
+++ b/DomainParser/DomainParser/ParsedHost.swift
@@ -15,3 +15,11 @@ public struct ParsedHost {
     public let domain: String?
 
 }
+
+extension ParsedHost: Equatable {
+
+    public static func == (lhs: ParsedHost, rhs: ParsedHost) -> Bool {
+        return (lhs.publicSuffix == rhs.publicSuffix && lhs.domain == rhs.domain)
+    }
+
+}

--- a/DomainParser/DomainParserTests/DomainParserTests.swift
+++ b/DomainParser/DomainParserTests/DomainParserTests.swift
@@ -130,5 +130,16 @@ class DomainParserTests: XCTestCase {
         guard let host = host else { return }
         XCTAssertEqual(domainParser.parse(host: host.lowercased())?.domain, expectedDomain, file: file, line: line)
     }
+
+
+    func testTLDWithNoDomain() {
+        XCTAssertEqual(domainParser.parse(host: "com"), ParsedHost(publicSuffix: "com", domain: nil))
+        XCTAssertEqual(domainParser.parse(host: "co.uk"), ParsedHost(publicSuffix: "co.uk", domain: nil))
+        XCTAssertEqual(domainParser.parse(host: "ide.kyoto.jp"), ParsedHost(publicSuffix: "ide.kyoto.jp", domain: nil))
+
+        // Wildcard
+        XCTAssertEqual(domainParser.parse(host: "any.ck"), ParsedHost(publicSuffix: "any.ck", domain: nil))
+        XCTAssertEqual(domainParser.parse(host: "any.mm"), ParsedHost(publicSuffix: "any.mm", domain: nil))
+    }
 }
 


### PR DESCRIPTION
Fix an inconsistent behaviour when parsing a hostname that contains just the TLD but no domain and add a unit-test for checking this.

Before this commit, `parse("com")?.publicSuffix == nil` (1-level TLD), but `parse("co.uk")?.publicSuffix == "co.uk"` (2-level or any multi-level TLD). 
Fix this by making `parse("com")?.publicSuffix` return `"com"` as well.